### PR TITLE
Update `shopify` script to Shopify CLI v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite build --watch",
     "build": "tsc && vite build",
-    "shopify": "cd shopify && shopify theme serve",
+    "shopify": "cd shopify && shopify theme dev",
     "install-theme": "ts-node scripts/install-theme.ts --repo=https://github.com/Shopify/dawn.git"
   },
   "keywords": [


### PR DESCRIPTION
Shopify has renamed the `shopify theme serve` command to `shopify theme dev` ([read more](https://shopify.dev/themes/tools/cli/migrate)). This PR update the `shopify` script in `package.json` accordingly.